### PR TITLE
Set later to use local time

### DIFF
--- a/prettycron.js
+++ b/prettycron.js
@@ -172,6 +172,7 @@ if ((!moment || !later) && (typeof require !== 'undefined')) {
    * (This is just a wrapper for later.js)
    */
   var getNextDate = function(cronspec, sixth) {
+    later.date.localTime();
     var schedule = later.parse.cron(cronspec, sixth);
     return later.schedule(schedule).next();
   };


### PR DESCRIPTION
Fixes #5 

From the docs:

All schedule definitions are completely timezone agnostic. When you need to calculate occurrences, you can decide to perform the calculation using local time or UTC.

  // set later to use UTC (the default)
  later.date.UTC();

  // set later to use local time
  later.date.localTime();
