### PR TITLE
Handle full list of day of month

### DIFF
--- a/prettycron.js
+++ b/prettycron.js
@@ -132,7 +132,7 @@ if ((!moment || !later) && (typeof require !== 'undefined')) {
       }
     }
 
-    if (schedule['D']) { // runs only on specific day(s) of month
+    if (schedule['D'] && schedule['D'].length !== 31) { // runs only on specific day(s) of month
       output_text += ' on the ' + numberList(schedule['D']);
       if (!schedule['M']) {
         output_text += ' of every month';


### PR DESCRIPTION
``` javascript
prettyCron.toString("0 0 18 1/1 * ? *", true)
```

 produces this : 
18:00 on the 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 and 31th of every month

This PR fixes this to produce : 
18:00
